### PR TITLE
添加 prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "format": "prettier --write external-protocol/*.ts internal-protocol/*.ts",
         "check:format": "prettier --check external-protocol/*.ts internal-protocol/*.ts",
         "lint": "eslint external-protocol internal-protocol --fix",
-        "check:lint": "eslint external-protocol internal-protocol -f codeframe"
+        "check:lint": "eslint external-protocol internal-protocol -f codeframe",
+        "prepack": "tsc"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.14.1",


### PR DESCRIPTION
修复 typescript 源代码在安装后需要编译的问题

参考 <https://stackoverflow.com/questions/51078974/how-to-have-npm-install-a-typescript-dependency-from-a-github-url>